### PR TITLE
Feat/6 kakao local enrichment

### DIFF
--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -131,6 +131,8 @@ async def get_job_result(
         caption=result.caption if result else None,
         instagram_meta=result.instagram_meta if result else None,
         extraction_result=result.extraction_result if result else None,
+        place_candidates=result.place_candidates if result else [],
+        selected_place=result.selected_place if result else None,
         error_message=job.error_message,
         updated_at=job.updated_at,
     )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -90,6 +90,7 @@ class Settings(BaseSettings):
     kakao_base_url: str = "https://dapi.kakao.com"
     kakao_timeout_seconds: int = 5
     kakao_max_places_per_candidate: int = 5
+    kakao_min_place_confidence: float = 0.7
 
     hf_extraction_endpoint_url: str = ""
     hf_extraction_api_token: str = ""

--- a/app/domain/job/model.py
+++ b/app/domain/job/model.py
@@ -46,6 +46,8 @@ class JobResultRecord:
     caption: str | None
     instagram_meta: dict[str, Any] | None
     extraction_result: dict[str, Any] | None
+    place_candidates: list[dict[str, Any]]
+    selected_place: dict[str, Any] | None
     created_at: datetime
     updated_at: datetime
 
@@ -60,11 +62,17 @@ class ExtractedCandidate:
 
 @dataclass(slots=True)
 class PlaceCandidate:
-    place_name: str
-    road_address: str | None
-    address: str | None
-    category: str | None
     kakao_place_id: str
+    place_name: str
+    category_name: str | None
+    category_group_code: str | None
+    category_group_name: str | None
+    phone: str | None
+    address_name: str | None
+    road_address_name: str | None
+    x: str | None
+    y: str | None
+    place_url: str | None
     confidence: float
     source_keyword: str
     source_sentence: str
@@ -83,11 +91,17 @@ class CrawlArtifact:
 
 def as_place_dict(place: PlaceCandidate) -> dict[str, Any]:
     return {
-        "place_name": place.place_name,
-        "road_address": place.road_address,
-        "address": place.address,
-        "category": place.category,
         "kakao_place_id": place.kakao_place_id,
+        "place_name": place.place_name,
+        "category_name": place.category_name,
+        "category_group_code": place.category_group_code,
+        "category_group_name": place.category_group_name,
+        "phone": place.phone,
+        "address_name": place.address_name,
+        "road_address_name": place.road_address_name,
+        "x": place.x,
+        "y": place.y,
+        "place_url": place.place_url,
         "confidence": round(place.confidence, 4),
         "source_keyword": place.source_keyword,
         "source_sentence": place.source_sentence,

--- a/app/infra/db/repository.py
+++ b/app/infra/db/repository.py
@@ -106,17 +106,21 @@ class JobRepository:
         caption: str | None,
         instagram_meta: dict[str, Any] | None,
         extraction_result: dict[str, Any] | None = None,
+        place_candidates: list[dict[str, Any]] | None = None,
+        selected_place: dict[str, Any] | None = None,
     ) -> JobResultRecord:
         sql = f"""
         INSERT INTO {self._results_table}
-            (job_id, caption, instagram_meta, extraction_result)
+            (job_id, caption, instagram_meta, extraction_result, place_candidates, selected_place)
         VALUES
-            ($1, $2, $3::jsonb, $4::jsonb)
+            ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb)
         ON CONFLICT (job_id)
         DO UPDATE SET
             caption = EXCLUDED.caption,
             instagram_meta = EXCLUDED.instagram_meta,
             extraction_result = EXCLUDED.extraction_result,
+            place_candidates = EXCLUDED.place_candidates,
+            selected_place = EXCLUDED.selected_place,
             updated_at = NOW()
         RETURNING *
         """
@@ -126,6 +130,8 @@ class JobRepository:
             caption,
             json.dumps(instagram_meta or {}),
             json.dumps(extraction_result) if extraction_result is not None else None,
+            json.dumps(place_candidates or []),
+            json.dumps(selected_place) if selected_place is not None else None,
         )
         if row is None:
             raise RuntimeError("Failed to upsert job result")
@@ -148,6 +154,8 @@ class JobRepository:
             caption=row["caption"],
             instagram_meta=self._json_to_dict(row["instagram_meta"]),
             extraction_result=self._json_to_dict(row["extraction_result"]),
+            place_candidates=self._json_to_list(row["place_candidates"]),
+            selected_place=self._json_to_dict(row["selected_place"]),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
         )
@@ -161,3 +169,13 @@ class JobRepository:
         if isinstance(value, dict):
             return value
         return dict(value)
+
+    @staticmethod
+    def _json_to_list(value: Any) -> list[dict[str, Any]]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = json.loads(value)
+        if isinstance(value, list):
+            return value
+        return list(value)

--- a/app/infra/kakao/client.py
+++ b/app/infra/kakao/client.py
@@ -28,9 +28,15 @@ class KakaoSearchResult:
 
 
 class KakaoLocalClient:
-    def __init__(self, settings: Settings) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
         self._settings = settings
         self._headers = {"Authorization": f"KakaoAK {settings.kakao_rest_api_key}"}
+        self._transport = transport
 
     async def search_places(
         self,
@@ -51,7 +57,7 @@ class KakaoLocalClient:
         url = f"{self._settings.kakao_base_url}/v2/local/search/keyword.json"
 
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(timeout=timeout, transport=self._transport) as client:
                 response = await client.get(url, params=params, headers=self._headers)
         except (httpx.TimeoutException, httpx.NetworkError) as exc:
             raise KakaoRetryableError(str(exc)) from exc
@@ -88,11 +94,17 @@ class KakaoLocalClient:
             confidence = self._score_place(candidate.keyword, place_name, idx, doc, location_hints)
             places.append(
                 PlaceCandidate(
-                    place_name=place_name,
-                    road_address=(doc.get("road_address_name") or "").strip() or None,
-                    address=(doc.get("address_name") or "").strip() or None,
-                    category=(doc.get("category_name") or "").strip() or None,
                     kakao_place_id=str(doc.get("id") or ""),
+                    place_name=place_name,
+                    category_name=(doc.get("category_name") or "").strip() or None,
+                    category_group_code=(doc.get("category_group_code") or "").strip() or None,
+                    category_group_name=(doc.get("category_group_name") or "").strip() or None,
+                    phone=(doc.get("phone") or "").strip() or None,
+                    address_name=(doc.get("address_name") or "").strip() or None,
+                    road_address_name=(doc.get("road_address_name") or "").strip() or None,
+                    x=(doc.get("x") or "").strip() or None,
+                    y=(doc.get("y") or "").strip() or None,
+                    place_url=(doc.get("place_url") or "").strip() or None,
                     confidence=confidence,
                     source_keyword=candidate.source_keyword,
                     source_sentence=candidate.source_sentence,
@@ -110,7 +122,7 @@ class KakaoLocalClient:
         location_hints: list[str],
     ) -> float:
         score = 0.35
-        if keyword.lower() in place_name.lower():
+        if _normalize_place_text(keyword) in _normalize_place_text(place_name):
             score += 0.3
         if rank == 0:
             score += 0.2
@@ -129,3 +141,7 @@ class KakaoLocalClient:
             score += 0.1
 
         return max(0.0, min(0.99, score))
+
+
+def _normalize_place_text(value: str) -> str:
+    return "".join((value or "").lower().split())

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -17,6 +17,24 @@ class ExtractionResultResponse(BaseModel):
     certainty: Literal["high", "medium", "low"]
 
 
+class PlaceCandidateResponse(BaseModel):
+    kakao_place_id: str
+    place_name: str
+    category_name: str | None = None
+    category_group_code: str | None = None
+    category_group_name: str | None = None
+    phone: str | None = None
+    address_name: str | None = None
+    road_address_name: str | None = None
+    x: str | None = None
+    y: str | None = None
+    place_url: str | None = None
+    confidence: float
+    source_keyword: str | None = None
+    source_sentence: str | None = None
+    raw_candidate: str | None = None
+
+
 class CreateJobRequest(BaseModel):
     url: HttpUrl = Field(..., examples=["https://www.instagram.com/reel/abcde/"])
     room_id: UUID
@@ -49,6 +67,8 @@ class JobResultResponse(BaseModel):
     caption: str | None
     instagram_meta: dict[str, object] | None
     extraction_result: ExtractionResultResponse | None = None
+    place_candidates: list[PlaceCandidateResponse] = Field(default_factory=list)
+    selected_place: PlaceCandidateResponse | None = None
     error_message: str | None
     updated_at: datetime
 

--- a/app/worker/processor.py
+++ b/app/worker/processor.py
@@ -11,10 +11,14 @@ from app.core.config import Settings
 from app.domain.crawl import crawl_and_parse
 from app.domain.job import (
     CrawlArtifact,
+    ExtractedCandidate,
     ExtractionResult,
     JobRecord,
+    PlaceCandidate,
     as_extraction_result_dict,
+    as_place_dict,
 )
+from app.infra.kakao import KakaoNonRetryableError
 
 logger = logging.getLogger("processing.worker.processor")
 
@@ -47,6 +51,18 @@ class ExtractionPort(Protocol):
     ) -> ExtractionResult | None: ...
 
 
+class PlaceSearchResultPort(Protocol):
+    places: list[PlaceCandidate]
+
+
+class PlaceSearchPort(Protocol):
+    async def search_places(
+        self,
+        candidate: ExtractedCandidate,
+        location_hints: list[str],
+    ) -> PlaceSearchResultPort: ...
+
+
 class JobProcessor:
     def __init__(
         self,
@@ -54,10 +70,12 @@ class JobProcessor:
         repository: JobRepositoryPort,
         settings: Settings,
         extraction_client: ExtractionPort | None = None,
+        place_search_client: PlaceSearchPort | None = None,
     ) -> None:
         self._repository = repository
         self._settings = settings
         self._extraction_client = extraction_client
+        self._place_search_client = place_search_client
 
     async def process_job(self, job_id: UUID) -> JobProcessOutcome:
         started = time.monotonic()
@@ -75,11 +93,15 @@ class JobProcessor:
         try:
             crawl_artifact = await crawl_and_parse(job.source_url, self._settings)
             extraction_result = await self._extract_result(job.source_url, crawl_artifact)
-            # TODO(kakao): Add Kakao Local enrichment and final place ranking in next migration step.
+            place_candidates, selected_place = await self._enrich_place(
+                extraction_result,
+                crawl_artifact,
+            )
             logger.info(
-                "job crawl completed job_id=%s caption_len=%s",
+                "job crawl completed job_id=%s caption_len=%s place_candidates=%s",
                 job.job_id,
                 len(crawl_artifact.caption or ""),
+                len(place_candidates),
             )
 
             await self._repository.upsert_job_result(
@@ -89,6 +111,8 @@ class JobProcessor:
                 extraction_result=(
                     as_extraction_result_dict(extraction_result) if extraction_result else None
                 ),
+                place_candidates=place_candidates,
+                selected_place=selected_place,
             )
             await self._repository.mark_succeeded(job.job_id)
             elapsed_ms = int((time.monotonic() - started) * 1000)
@@ -130,3 +154,59 @@ class JobProcessor:
         except Exception:
             logger.exception("extraction failed source_url=%s", source_url)
             return None
+
+    async def _enrich_place(
+        self,
+        extraction_result: ExtractionResult | None,
+        crawl_artifact: CrawlArtifact,
+    ) -> tuple[list[dict[str, object]], dict[str, object] | None]:
+        if not self._place_search_client or not extraction_result:
+            return [], None
+
+        store_name = (extraction_result.store_name or "").strip()
+        if not store_name:
+            return [], None
+
+        candidate = ExtractedCandidate(
+            keyword=store_name,
+            source_keyword=store_name,
+            source_sentence=(
+                extraction_result.store_name_evidence
+                or extraction_result.address_evidence
+                or crawl_artifact.caption
+                or ""
+            ),
+            raw_candidate=store_name,
+        )
+        location_hints = [extraction_result.address.strip()] if extraction_result.address else []
+
+        try:
+            places = await self._search_places(candidate, location_hints)
+            if not places and location_hints:
+                places = await self._search_places(candidate, [])
+        except KakaoNonRetryableError:
+            logger.error("kakao enrichment non-retryable failure", exc_info=True)
+            return [], None
+        except Exception:
+            logger.exception("kakao enrichment failed")
+            return [], None
+
+        places = sorted(places, key=lambda place: place.confidence, reverse=True)
+        places = [
+            place
+            for place in places
+            if place.confidence >= self._settings.kakao_min_place_confidence
+        ]
+        place_candidates = [as_place_dict(place) for place in places]
+        selected_place = place_candidates[0] if place_candidates else None
+        return place_candidates, selected_place
+
+    async def _search_places(
+        self,
+        candidate: ExtractedCandidate,
+        location_hints: list[str],
+    ) -> list[PlaceCandidate]:
+        if not self._place_search_client:
+            return []
+        result = await self._place_search_client.search_places(candidate, location_hints)
+        return result.places

--- a/app/worker/processor.py
+++ b/app/worker/processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from dataclasses import dataclass
 from typing import Protocol
@@ -178,12 +179,10 @@ class JobProcessor:
             ),
             raw_candidate=store_name,
         )
-        location_hints = [extraction_result.address.strip()] if extraction_result.address else []
+        location_hints = self._build_location_hints(extraction_result.address)
 
         try:
-            places = await self._search_places(candidate, location_hints)
-            if not places and location_hints:
-                places = await self._search_places(candidate, [])
+            places = await self._search_places_by_hints(candidate, location_hints)
         except KakaoNonRetryableError:
             logger.error("kakao enrichment non-retryable failure", exc_info=True)
             return [], None
@@ -210,3 +209,80 @@ class JobProcessor:
             return []
         result = await self._place_search_client.search_places(candidate, location_hints)
         return result.places
+
+    async def _search_places_by_hints(
+        self,
+        candidate: ExtractedCandidate,
+        location_hints: list[str],
+    ) -> list[PlaceCandidate]:
+        for hint in location_hints:
+            places = await self._search_places(candidate, [hint])
+            qualified = self._qualified_places(places)
+            if qualified:
+                return qualified
+
+        places = await self._search_places(candidate, [])
+        return self._qualified_places(places)
+
+    def _qualified_places(self, places: list[PlaceCandidate]) -> list[PlaceCandidate]:
+        return [
+            place
+            for place in places
+            if place.confidence >= self._settings.kakao_min_place_confidence
+        ]
+
+    @staticmethod
+    def _build_location_hints(address: str | None) -> list[str]:
+        raw = (address or "").strip()
+        if not raw:
+            return []
+
+        tokens = [token.strip(",") for token in re.split(r"\s+", raw) if token.strip(",")]
+        hints = [raw]
+
+        district_suffixes = ("\uad6c", "\uad70")
+        locality_suffixes = ("\ub3d9", "\uc74d", "\uba74", "\ub9ac", "\uac00")
+
+        district_idx = next(
+            (idx for idx, token in enumerate(tokens) if token.endswith(district_suffixes)),
+            None,
+        )
+        if district_idx is not None:
+            hints.append(" ".join(tokens[: district_idx + 1]))
+
+            locality_idx = next(
+                (
+                    idx
+                    for idx in range(district_idx + 1, len(tokens))
+                    if tokens[idx].endswith(locality_suffixes)
+                ),
+                None,
+            )
+            if locality_idx is not None:
+                hints.append(" ".join(tokens[: locality_idx + 1]))
+
+            road_hint = JobProcessor._build_road_hint(tokens, district_idx)
+            if road_hint:
+                hints.append(road_hint)
+
+        deduped: list[str] = []
+        for hint in hints:
+            if hint and hint not in deduped:
+                deduped.append(hint)
+        return deduped
+
+    @staticmethod
+    def _build_road_hint(tokens: list[str], district_idx: int) -> str | None:
+        prefix = tokens[: district_idx + 1]
+        rest = tokens[district_idx + 1 :]
+        if not prefix or not rest:
+            return None
+
+        for idx, token in enumerate(rest):
+            if token.endswith("\uae38"):
+                return " ".join(prefix + [token])
+            if token.endswith("\ub85c"):
+                if idx + 1 < len(rest) and re.fullmatch(r"\d+\uae38", rest[idx + 1]):
+                    return " ".join(prefix + [f"{token}{rest[idx + 1]}"])
+                return " ".join(prefix + [token])
+        return None

--- a/app/worker/runner.py
+++ b/app/worker/runner.py
@@ -8,6 +8,7 @@ import time
 
 from app.core.config import get_settings
 from app.infra.db import JobRepository, create_db_pool
+from app.infra.kakao import KakaoLocalClient
 from app.infra.llm import HFExtractionClient
 from app.infra.queue import RedisJobQueue
 from app.services.crawler.playwright_service import prewarm_crawler_runtime, shutdown_crawler_runtime
@@ -92,6 +93,13 @@ def build_extraction_client(settings) -> ExtractionPort | None:
     return HFExtractionClient(settings)
 
 
+def build_place_search_client(settings):
+    if not settings.kakao_rest_api_key:
+        logger.warning("worker kakao client disabled (KAKAO_REST_API_KEY is empty)")
+        return None
+    return KakaoLocalClient(settings)
+
+
 async def run_worker() -> None:
     settings = get_settings()
     pool = await create_db_pool(settings)
@@ -103,6 +111,7 @@ async def run_worker() -> None:
         repository=repository,
         settings=settings,
         extraction_client=build_extraction_client(settings),
+        place_search_client=build_place_search_client(settings),
     )
 
     if settings.worker_prewarm_browser:

--- a/migrations/002_add_kakao_place_results_to_job_results.sql
+++ b/migrations/002_add_kakao_place_results_to_job_results.sql
@@ -1,0 +1,3 @@
+ALTER TABLE processing.job_results
+ADD COLUMN IF NOT EXISTS place_candidates JSONB NOT NULL DEFAULT '[]'::jsonb,
+ADD COLUMN IF NOT EXISTS selected_place JSONB;

--- a/tests/test_job_repository.py
+++ b/tests/test_job_repository.py
@@ -50,6 +50,8 @@ class FakePool:
             "caption": args[1],
             "instagram_meta": args[2],
             "extraction_result": args[3],
+            "place_candidates": args[4],
+            "selected_place": args[5],
             "created_at": now,
             "updated_at": now,
         }
@@ -67,6 +69,23 @@ def test_upsert_job_result_persists_extraction_result() -> None:
         "address_evidence": "1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
         "certainty": "high",
     }
+    selected_place = {
+        "kakao_place_id": "123",
+        "place_name": "Common Mansion",
+        "category_name": "음식점 > 카페",
+        "category_group_code": "CE7",
+        "category_group_name": "카페",
+        "phone": "02-0000-0000",
+        "address_name": "서울 종로구 신문로2가 1-102",
+        "road_address_name": "서울 종로구 새문안로 1",
+        "x": "126.970000",
+        "y": "37.570000",
+        "place_url": "https://place.map.kakao.com/123",
+        "confidence": 0.95,
+        "source_keyword": "Common Mansion",
+        "source_sentence": "Common Mansion 1-102 Sinmunro 2-ga",
+        "raw_candidate": "Common Mansion",
+    }
 
     record = _run(
         repository.upsert_job_result(
@@ -74,6 +93,8 @@ def test_upsert_job_result_persists_extraction_result() -> None:
             caption="Common Mansion review",
             instagram_meta={"media_type": "reel"},
             extraction_result=extraction_result,
+            place_candidates=[selected_place],
+            selected_place=selected_place,
         )
     )
 
@@ -85,8 +106,12 @@ def test_upsert_job_result_persists_extraction_result() -> None:
         "Common Mansion review",
         json.dumps({"media_type": "reel"}),
         json.dumps(extraction_result),
+        json.dumps([selected_place]),
+        json.dumps(selected_place),
     )
     assert record.extraction_result == extraction_result
+    assert record.place_candidates == [selected_place]
+    assert record.selected_place == selected_place
 
 
 @pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
@@ -106,6 +131,8 @@ def test_get_job_result_maps_extraction_result() -> None:
             "caption": "caption",
             "instagram_meta": json.dumps({"caption": "caption"}),
             "extraction_result": json.dumps(extraction_result),
+            "place_candidates": json.dumps([]),
+            "selected_place": None,
             "created_at": now,
             "updated_at": now,
         }
@@ -116,3 +143,5 @@ def test_get_job_result_maps_extraction_result() -> None:
 
     assert record is not None
     assert record.extraction_result == extraction_result
+    assert record.place_candidates == []
+    assert record.selected_place is None

--- a/tests/test_job_result_schema.py
+++ b/tests/test_job_result_schema.py
@@ -45,3 +45,45 @@ def test_job_result_response_allows_missing_extraction_result() -> None:
     )
 
     assert response.extraction_result is None
+    assert response.place_candidates == []
+    assert response.selected_place is None
+
+
+def test_job_result_response_accepts_kakao_place_result() -> None:
+    selected_place = {
+        "kakao_place_id": "123",
+        "place_name": "커먼맨션",
+        "category_name": "음식점 > 카페",
+        "category_group_code": "CE7",
+        "category_group_name": "카페",
+        "address_name": "서울 종로구 신문로2가 1-102",
+        "road_address_name": "서울 종로구 새문안로 1",
+        "x": "126.970000",
+        "y": "37.570000",
+        "place_url": "https://place.map.kakao.com/123",
+        "phone": None,
+        "confidence": 0.95,
+        "source_keyword": "커먼맨션",
+        "source_sentence": "브런치 맛집 커먼맨션 입니다",
+        "raw_candidate": "커먼맨션",
+    }
+
+    response = JobResultResponse(
+        job_id=uuid4(),
+        source_url="https://www.instagram.com/reel/example/",
+        source="instagram",
+        status=JobStatus.SUCCEEDED,
+        caption="caption",
+        instagram_meta=None,
+        extraction_result=None,
+        place_candidates=[selected_place],
+        selected_place=selected_place,
+        error_message=None,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    dumped = response.model_dump()
+
+    assert dumped["selected_place"]["place_name"] == "커먼맨션"
+    assert dumped["selected_place"]["category_group_code"] == "CE7"
+    assert dumped["place_candidates"][0]["road_address_name"] == "서울 종로구 새문안로 1"

--- a/tests/test_jobs_api_result.py
+++ b/tests/test_jobs_api_result.py
@@ -40,6 +40,23 @@ def test_get_job_result_returns_extraction_result() -> None:
         "address_evidence": "1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
         "certainty": "high",
     }
+    selected_place = {
+        "kakao_place_id": "123",
+        "place_name": "Common Mansion",
+        "category_name": "음식점 > 카페",
+        "category_group_code": "CE7",
+        "category_group_name": "카페",
+        "phone": None,
+        "address_name": "서울 종로구 신문로2가 1-102",
+        "road_address_name": "서울 종로구 새문안로 1",
+        "x": "126.970000",
+        "y": "37.570000",
+        "place_url": "https://place.map.kakao.com/123",
+        "confidence": 0.95,
+        "source_keyword": "Common Mansion",
+        "source_sentence": "Common Mansion 1-102 Sinmunro 2-ga",
+        "raw_candidate": "Common Mansion",
+    }
     app = FastAPI()
     app.include_router(router)
     app.state.job_service = FakeJobService(
@@ -59,6 +76,8 @@ def test_get_job_result_returns_extraction_result() -> None:
             caption="Common Mansion review",
             instagram_meta={"media_type": "reel"},
             extraction_result=extraction_result,
+            place_candidates=[selected_place],
+            selected_place=selected_place,
             created_at=now,
             updated_at=now,
         )
@@ -72,3 +91,5 @@ def test_get_job_result_returns_extraction_result() -> None:
 
     assert response.status_code == 200
     assert response.json()["extraction_result"] == extraction_result
+    assert response.json()["place_candidates"] == [selected_place]
+    assert response.json()["selected_place"] == selected_place

--- a/tests/test_kakao_client.py
+++ b/tests/test_kakao_client.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from app.core.config import Settings
+from app.domain.job import ExtractedCandidate
+from app.infra.kakao import KakaoLocalClient, KakaoNonRetryableError
+
+if hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+def _can_create_event_loop() -> bool:
+    try:
+        loop = asyncio.new_event_loop()
+        loop.close()
+        return True
+    except OSError:
+        return False
+
+
+EVENT_LOOP_AVAILABLE = _can_create_event_loop()
+
+
+def _run(coro):
+    try:
+        return asyncio.run(coro)
+    except OSError as exc:
+        pytest.skip(f"Event loop creation is blocked in this environment: {exc}")
+
+
+def _settings() -> Settings:
+    return Settings(
+        kakao_rest_api_key="test-kakao-key",
+        kakao_base_url="https://dapi.kakao.com",
+        kakao_max_places_per_candidate=5,
+    )
+
+
+def _candidate() -> ExtractedCandidate:
+    return ExtractedCandidate(
+        keyword="커먼맨션",
+        source_keyword="커먼맨션",
+        source_sentence="브런치 맛집 커먼맨션 입니다",
+        raw_candidate="커먼맨션",
+    )
+
+
+@pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
+def test_kakao_local_client_maps_place_fields() -> None:
+    seen_requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "documents": [
+                    {
+                        "id": "123",
+                        "place_name": "커먼맨션",
+                        "category_name": "음식점 > 카페",
+                        "category_group_code": "CE7",
+                        "category_group_name": "카페",
+                        "phone": "02-0000-0000",
+                        "address_name": "서울 종로구 신문로2가 1-102",
+                        "road_address_name": "서울 종로구 새문안로 1",
+                        "x": "126.970000",
+                        "y": "37.570000",
+                        "place_url": "https://place.map.kakao.com/123",
+                    }
+                ],
+                "meta": {"total_count": 1},
+            },
+        )
+
+    client = KakaoLocalClient(
+        _settings(),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = _run(
+        client.search_places(
+            _candidate(),
+            location_hints=["서울 종로구 신문로2가 1-102"],
+        )
+    )
+
+    assert seen_requests[0].headers["Authorization"] == "KakaoAK test-kakao-key"
+    assert seen_requests[0].url.params["query"] == "서울 종로구 신문로2가 1-102 커먼맨션"
+    assert seen_requests[0].url.params["size"] == "5"
+    place = result.places[0]
+    assert place.kakao_place_id == "123"
+    assert place.place_name == "커먼맨션"
+    assert place.category_name == "음식점 > 카페"
+    assert place.category_group_code == "CE7"
+    assert place.category_group_name == "카페"
+    assert place.address_name == "서울 종로구 신문로2가 1-102"
+    assert place.road_address_name == "서울 종로구 새문안로 1"
+    assert place.x == "126.970000"
+    assert place.y == "37.570000"
+    assert place.place_url == "https://place.map.kakao.com/123"
+    assert place.confidence > 0
+
+
+@pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
+def test_kakao_local_client_requires_api_key() -> None:
+    client = KakaoLocalClient(Settings(kakao_rest_api_key=""))
+
+    with pytest.raises(KakaoNonRetryableError):
+        _run(client.search_places(_candidate(), []))

--- a/tests/test_worker_processor.py
+++ b/tests/test_worker_processor.py
@@ -120,6 +120,16 @@ class FakePlaceSearchClient:
         return FakePlaceSearchResult(self.places)
 
 
+class HintAwarePlaceSearchClient:
+    def __init__(self, places_by_hint: dict[tuple[str, ...], list[PlaceCandidate]]) -> None:
+        self.places_by_hint = places_by_hint
+        self.calls: list[list[str]] = []
+
+    async def search_places(self, candidate, location_hints: list[str]) -> FakePlaceSearchResult:
+        self.calls.append(location_hints)
+        return FakePlaceSearchResult(self.places_by_hint.get(tuple(location_hints), []))
+
+
 class FailingPlaceSearchClient:
     async def search_places(self, candidate, location_hints: list[str]) -> FakePlaceSearchResult:
         raise RuntimeError("kakao unavailable")
@@ -242,6 +252,70 @@ def test_processor_passes_caption_to_extraction_client(monkeypatch) -> None:
         "certainty": "high",
     }
     assert repo.failed is None
+
+
+@pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
+def test_processor_tries_broader_location_hints_before_keyword_only(monkeypatch) -> None:
+    job = _new_job()
+    repo = FakeRepository(job)
+    settings = Settings(kakao_min_place_confidence=0.7)
+    extractor = FakeExtractionClient(
+        ExtractionResult(
+            store_name="Geumdonok",
+            address="서울 서초구 방배로 23길 31-6",
+            store_name_evidence="Geumdonok",
+            address_evidence="서울 서초구 방배로 23길 31-6",
+            certainty=ExtractionCertainty.HIGH,
+        )
+    )
+    place = _place_candidate(confidence=0.95)
+    place_search = HintAwarePlaceSearchClient(
+        {
+            ("서울 서초구",): [place],
+            tuple(): [_place_candidate(confidence=0.85)],
+        }
+    )
+
+    async def fake_crawl(url: str, _settings: Settings) -> CrawlArtifact:
+        return CrawlArtifact(
+            url=url,
+            html=None,
+            text="Geumdonok 서울 서초구 방배로 23길 31-6",
+            media_type="reel",
+            caption="Geumdonok 서울 서초구 방배로 23길 31-6",
+            instagram_meta=None,
+        )
+
+    monkeypatch.setattr("app.worker.processor.crawl_and_parse", fake_crawl)
+
+    processor = JobProcessor(
+        repository=repo,
+        settings=settings,
+        extraction_client=extractor,
+        place_search_client=place_search,
+    )
+
+    _run(processor.process_job(job.job_id))
+
+    assert place_search.calls == [
+        ["서울 서초구 방배로 23길 31-6"],
+        ["서울 서초구"],
+    ]
+    assert repo.saved_result is not None
+    assert repo.saved_result["selected_place"]["confidence"] == 0.95
+
+
+def test_build_location_hints_from_korean_address() -> None:
+    assert JobProcessor._build_location_hints("서울 서초구 방배로 23길 31-6") == [
+        "서울 서초구 방배로 23길 31-6",
+        "서울 서초구",
+        "서울 서초구 방배로23길",
+    ]
+    assert JobProcessor._build_location_hints("서울 강남구 도곡동 954-17") == [
+        "서울 강남구 도곡동 954-17",
+        "서울 강남구",
+        "서울 강남구 도곡동",
+    ]
 
 
 @pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")

--- a/tests/test_worker_processor.py
+++ b/tests/test_worker_processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
@@ -13,6 +14,7 @@ from app.domain.job import (
     ExtractionResult,
     JobRecord,
     JobStatus,
+    PlaceCandidate,
 )
 from app.worker.processor import JobProcessor
 
@@ -97,6 +99,32 @@ class FailingExtractionClient:
         raise RuntimeError("endpoint unavailable")
 
 
+@dataclass
+class FakePlaceSearchResult:
+    places: list[PlaceCandidate]
+
+
+class FakePlaceSearchClient:
+    def __init__(self, places: list[PlaceCandidate]) -> None:
+        self.places = places
+        self.calls: list[dict[str, object]] = []
+
+    async def search_places(self, candidate, location_hints: list[str]) -> FakePlaceSearchResult:
+        self.calls.append(
+            {
+                "keyword": candidate.keyword,
+                "source_keyword": candidate.source_keyword,
+                "location_hints": location_hints,
+            }
+        )
+        return FakePlaceSearchResult(self.places)
+
+
+class FailingPlaceSearchClient:
+    async def search_places(self, candidate, location_hints: list[str]) -> FakePlaceSearchResult:
+        raise RuntimeError("kakao unavailable")
+
+
 def _new_job() -> JobRecord:
     now = datetime.now(timezone.utc)
     return JobRecord(
@@ -107,6 +135,26 @@ def _new_job() -> JobRecord:
         error_message=None,
         created_at=now,
         updated_at=now,
+    )
+
+
+def _place_candidate(*, confidence: float = 0.95) -> PlaceCandidate:
+    return PlaceCandidate(
+        kakao_place_id="123",
+        place_name="Common Mansion",
+        category_name="Food > Cafe",
+        category_group_code="CE7",
+        category_group_name="Cafe",
+        phone="02-0000-0000",
+        address_name="Seoul Jongno-gu Sinmunro 2-ga 1-102",
+        road_address_name="Seoul Jongno-gu Saemunan-ro 1",
+        x="126.970000",
+        y="37.570000",
+        place_url="https://place.map.kakao.com/123",
+        confidence=confidence,
+        source_keyword="Common Mansion",
+        source_sentence="Common Mansion 1-102 Sinmunro 2-ga",
+        raw_candidate="Common Mansion",
     )
 
 
@@ -193,6 +241,149 @@ def test_processor_passes_caption_to_extraction_client(monkeypatch) -> None:
         "address_evidence": "1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
         "certainty": "high",
     }
+    assert repo.failed is None
+
+
+@pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
+def test_processor_enriches_place_from_extraction_result(monkeypatch) -> None:
+    job = _new_job()
+    repo = FakeRepository(job)
+    settings = Settings()
+    extractor = FakeExtractionClient(
+        ExtractionResult(
+            store_name="Common Mansion",
+            address="1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            store_name_evidence="Common Mansion",
+            address_evidence="1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            certainty=ExtractionCertainty.HIGH,
+        )
+    )
+    place_search = FakePlaceSearchClient(
+        [
+            _place_candidate(confidence=0.75),
+            _place_candidate(confidence=0.95),
+        ]
+    )
+
+    async def fake_crawl(url: str, _settings: Settings) -> CrawlArtifact:
+        return CrawlArtifact(
+            url=url,
+            html=None,
+            text="Common Mansion 1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            media_type="reel",
+            caption="Common Mansion 1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            instagram_meta=None,
+        )
+
+    monkeypatch.setattr("app.worker.processor.crawl_and_parse", fake_crawl)
+
+    processor = JobProcessor(
+        repository=repo,
+        settings=settings,
+        extraction_client=extractor,
+        place_search_client=place_search,
+    )
+
+    _run(processor.process_job(job.job_id))
+
+    assert place_search.calls == [
+        {
+            "keyword": "Common Mansion",
+            "source_keyword": "Common Mansion",
+            "location_hints": ["1-102 Sinmunro 2-ga, Jongno-gu, Seoul"],
+        }
+    ]
+    assert repo.succeeded is True
+    assert repo.saved_result is not None
+    assert len(repo.saved_result["place_candidates"]) == 2
+    assert repo.saved_result["selected_place"]["confidence"] == 0.95
+    assert repo.saved_result["selected_place"]["kakao_place_id"] == "123"
+    assert repo.failed is None
+
+
+@pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
+def test_processor_succeeds_when_place_search_fails(monkeypatch) -> None:
+    job = _new_job()
+    repo = FakeRepository(job)
+    settings = Settings()
+    extractor = FakeExtractionClient(
+        ExtractionResult(
+            store_name="Common Mansion",
+            address="1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            store_name_evidence="Common Mansion",
+            address_evidence="1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            certainty=ExtractionCertainty.HIGH,
+        )
+    )
+
+    async def fake_crawl(url: str, _settings: Settings) -> CrawlArtifact:
+        return CrawlArtifact(
+            url=url,
+            html=None,
+            text="Common Mansion 1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            media_type="reel",
+            caption="Common Mansion 1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            instagram_meta=None,
+        )
+
+    monkeypatch.setattr("app.worker.processor.crawl_and_parse", fake_crawl)
+
+    processor = JobProcessor(
+        repository=repo,
+        settings=settings,
+        extraction_client=extractor,
+        place_search_client=FailingPlaceSearchClient(),
+    )
+
+    _run(processor.process_job(job.job_id))
+
+    assert repo.succeeded is True
+    assert repo.saved_result is not None
+    assert repo.saved_result["place_candidates"] == []
+    assert repo.saved_result["selected_place"] is None
+    assert repo.failed is None
+
+
+@pytest.mark.skipif(not EVENT_LOOP_AVAILABLE, reason="Event loop creation is blocked in this environment")
+def test_processor_drops_low_confidence_place_candidates(monkeypatch) -> None:
+    job = _new_job()
+    repo = FakeRepository(job)
+    settings = Settings(kakao_min_place_confidence=0.7)
+    extractor = FakeExtractionClient(
+        ExtractionResult(
+            store_name="Common Mansion",
+            address="1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            store_name_evidence="Common Mansion",
+            address_evidence="1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            certainty=ExtractionCertainty.HIGH,
+        )
+    )
+
+    async def fake_crawl(url: str, _settings: Settings) -> CrawlArtifact:
+        return CrawlArtifact(
+            url=url,
+            html=None,
+            text="Common Mansion 1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            media_type="reel",
+            caption="Common Mansion 1-102 Sinmunro 2-ga, Jongno-gu, Seoul",
+            instagram_meta=None,
+        )
+
+    monkeypatch.setattr("app.worker.processor.crawl_and_parse", fake_crawl)
+
+    processor = JobProcessor(
+        repository=repo,
+        settings=settings,
+        extraction_client=extractor,
+        place_search_client=FakePlaceSearchClient([_place_candidate(confidence=0.55)]),
+    )
+
+    _run(processor.process_job(job.job_id))
+
+    assert repo.succeeded is True
+    assert repo.saved_result is not None
+    assert repo.saved_result["place_candidates"] == []
+    assert repo.saved_result["selected_place"] is None
     assert repo.failed is None
 
 

--- a/tests/test_worker_runner.py
+++ b/tests/test_worker_runner.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from app.core.config import Settings
+from app.infra.kakao import KakaoLocalClient
 from app.infra.llm import HFExtractionClient
-from app.worker.runner import build_extraction_client
+from app.worker.runner import build_extraction_client, build_place_search_client
 
 
 def test_build_extraction_client_returns_none_without_endpoint() -> None:
@@ -30,3 +31,15 @@ def test_build_extraction_client_returns_hf_client_when_configured() -> None:
     )
 
     assert isinstance(build_extraction_client(settings), HFExtractionClient)
+
+
+def test_build_place_search_client_returns_none_without_key() -> None:
+    settings = Settings(kakao_rest_api_key="")
+
+    assert build_place_search_client(settings) is None
+
+
+def test_build_place_search_client_returns_kakao_client_when_configured() -> None:
+    settings = Settings(kakao_rest_api_key="test-kakao-key")
+
+    assert isinstance(build_place_search_client(settings), KakaoLocalClient)


### PR DESCRIPTION
## ✨ 무엇을 바꿨나요?

LLM이 추출한 상호명/주소를 기반으로 Kakao Local API에서 실제 장소 후보를 검색하고, 최종 선택된 장소를 `job_results`에 저장하도록 worker pipeline을 확장했습니다.

`/jobs/{jobId}/result` 응답에서도 Kakao 장소 후보와 최종 선택 장소를 반환합니다.

## 🔗 관련 이슈

Closes #6

## 💡 왜 바꿨나요?

이전 단계에서는 caption에서 `store_name`, `address`를 추출해 `extraction_result`로 저장하는 데까지 연결했습니다.

이번 단계에서는 추출된 상호명/주소를 실제 Kakao Local 장소 정보와 연결해, Spring Boot 서버가 사용할 수 있는 확정 장소 정보를 제공해야 합니다.

팀 논의에 따라 caption의 주소는 검색 힌트로 사용하고, 실제 저장되는 장소 정보는 Kakao Local API 응답 기준으로 확정합니다.

## 📝 주요 변경 사항

- `job_results`에 Kakao 장소 결과 저장 컬럼 추가
  - `place_candidates JSONB`
  - `selected_place JSONB`
- `JobRepository.upsert_job_result()`에서 장소 후보/최종 장소 저장
- `JobRepository.get_job_result()`에서 장소 후보/최종 장소 조회
- `/jobs/{jobId}/result` 응답에 아래 필드 추가
  - `place_candidates`
  - `selected_place`
- Kakao Local API 응답 매핑 확장
  - `kakao_place_id`
  - `place_name`
  - `category_name`
  - `category_group_code`
  - `category_group_name`
  - `address_name`
  - `road_address_name`
  - `x`
  - `y`
  - `place_url`
  - `phone`
- worker pipeline에 Kakao Local enrichment 단계 연결
- `KAKAO_REST_API_KEY` 기반 Kakao client 생성 로직 추가
- `kakao_min_place_confidence=0.7` 설정 추가
- 관련 repository/schema/API/worker/Kakao client 테스트 추가

## 🔎 Kakao 검색 전략

처음에는 단순히 `전체 주소 + 상호명`으로 검색하고, 실패하면 `상호명 단독`으로 fallback하는 방식을 생각했습니다.

하지만 실제 Kakao Local smoke 결과에서 문제가 있었습니다.

예를 들어 `금돈옥` 케이스에서:

text
LLM 추출 상호명: 금돈옥
LLM 추출 주소: 서울 서초구 방배로 23길 31-6

=> 단순 fallback으로 금돈옥만 검색하면 금돈옥 청담점이 먼저 잡힐 수 있었습니다.

그래서 주소를 완전히 버리지 않고, 한국 주소 접미사 패턴을 이용해 검색 힌트를 단계적으로 넓히는 방식으로 수정했습니다.

예:서울 서초구 방배로 23길 31-6

에서 다음 순서로 검색합니다.

1. 서울 서초구 방배로 23길 31-6 + 금돈옥
2. 서울 서초구 + 금돈옥
3. 서울 서초구 방배로23길 + 금돈옥
4. 금돈옥

주소 파싱은 무거운 주소 parser를 넣지 않고, 다음 접미사를 기준으로 보수적으로 처리했습니다.

구/군: 지역 힌트
동/읍/면/리/가: 동네 힌트
로/길: 도로명 힌트

또한 검색된 후보의 주소가 추출 주소와 다르더라도 버리지는 않기로 했습니다. 대신 confidence 기준을 두어 너무 약한 후보만 제외합니다.

kakao_min_place_confidence = 0.7

## ⚠️ 실패/예외 처리 정책

1. KAKAO_REST_API_KEY가 없으면 Kakao client를 비활성화하고 warning 로그를 남깁니다.
2. Kakao 인증/설정 오류는 error 로그를 남기되 job 전체 실패로 전파하지 않습니다.
3. Kakao 검색 실패 또는 결과 없음은 job 성공으로 처리합니다.

이 경우:
place_candidates=[]
selected_place=null

## 🧪 테스트
.\.venv\Scripts\python.exe -m pytest
결과:

53 passed

## 🧪 실제 Kakao Local smoke
로컬 artifact의 HF extraction 결과를 기반으로 실제 Kakao Local API를 호출해 확인했습니다.

생성 artifact:

artifacts/kakao_local_enrichment_samples.json
요약:

total=9
selected_count=6
error_count=0

올바르게 선택된 장소 예시:
#2 커먼맨션 | FD6 | x=126.97001457793 | y=37.5727427657281
#3 문보핫팟 | FD6 | x=127.05109755722185 | y=37.52529073455959
#4 요리미치 | FD6 | x=127.07641826816246 | y=37.55899426771555
#5 금돈옥 방배점 | FD6 | x=126.989198471873 | y=37.4866454677104
#6 한사발포차 양재점 | FD6 | x=127.03577238878559 | y=37.485523295753126
#7 인바이트 | CE7 | x=126.908674235964 | y=37.55588334709647
#1, #8, #9는 Kakao Local 문제가 아니라 LLM이 상호명을 잘못 추출한 케이스였습니다.

#1 실제: 후루사토 / LLM: 안주 오마카세집
#8 실제: 방울과꼬막 / LLM: 한우사골칼국수
#9 실제: 호이식 / LLM: 한옥 닭 칼국수
이 부분은 다음 이슈에서 caption marker fallback으로 보완할 예정입니다.